### PR TITLE
Update README.md

### DIFF
--- a/images/merger/README.md
+++ b/images/merger/README.md
@@ -26,4 +26,4 @@ python mergerGUI.py
 Use the interface to select input folder, output folder, file name, and orientation.
 
 ## License
-MIT
+GPL-3.0

--- a/mangadex/reddit/README.md
+++ b/mangadex/reddit/README.md
@@ -22,4 +22,4 @@ python the_site_is_okay_bot.py
 ```
 
 ## License
-MIT
+GPL-3.0

--- a/mangadex/userscripts/README.md
+++ b/mangadex/userscripts/README.md
@@ -14,4 +14,4 @@ A collection of UserScripts for MangaDex and related sites.
 2. Import the `.user.js` file into your extension.
 
 ## License
-MIT
+GPL-3.0

--- a/scraping/Webtoons/README.md
+++ b/scraping/Webtoons/README.md
@@ -33,4 +33,4 @@ python webtoonsSeriesScraper.py
 ```
 
 ## License
-MIT
+GPL-3.0


### PR DESCRIPTION
This pull request updates the licensing information across multiple README files in the project. The license has been changed from MIT to GPL-3.0 to reflect the correct license.

License updates:

* [`images/merger/README.md`](diffhunk://#diff-acb33aae4359e9de3fef7952ec3d4db411cee77146261399ec356a57a0b46f4fL29-R29): Updated the license from MIT to GPL-3.0.
* [`mangadex/reddit/README.md`](diffhunk://#diff-84017c408dfdcc69564084aab1d7aa86ba0fe3a71aff6a0988e5d3a5fcd13e0fL25-R25): Updated the license from MIT to GPL-3.0.
* [`mangadex/userscripts/README.md`](diffhunk://#diff-5149065d2086df3b717ed5a14646958c73cc52454f477f487ce44b2db807c869L17-R17): Updated the license from MIT to GPL-3.0.
* [`scraping/Webtoons/README.md`](diffhunk://#diff-af95cdf8806a0a266158d6950d2f77987a5a976db6aee2d6ba051011aa23b726L36-R36): Updated the license from MIT to GPL-3.0.